### PR TITLE
fix: use database connection pool and close all connections when app is shutting down

### DIFF
--- a/app/db/sqlalchemy.py
+++ b/app/db/sqlalchemy.py
@@ -1,9 +1,17 @@
 """SQLAlchemy helpers."""
 
+from asyncio import current_task
 from typing import Callable
 
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_scoped_session,
+    create_async_engine,
+)
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.pool.impl import AsyncAdaptedQueuePool
 
 from app.settings import settings
 
@@ -22,15 +30,24 @@ def make_url_sync(url: str) -> str:
 
 Base = declarative_base()
 
+engine: AsyncEngine = create_async_engine(
+    make_url_async(settings.POSTGRES_DSN), poolclass=AsyncAdaptedQueuePool
+)
+
 
 async def build_db_session_factory() -> AsyncSessionFactory:
-    engine = create_async_engine(make_url_async(settings.POSTGRES_DSN))
-
     await verify_db_connection(engine)
 
-    return sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+    return async_scoped_session(
+        sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession),
+        scopefunc=current_task,
+    )
 
 
 async def verify_db_connection(engine: AsyncEngine) -> None:
     connection = await engine.connect()
     await connection.close()
+
+
+async def close_db_connections() -> None:
+    await engine.dispose()

--- a/app/db/sqlalchemy.py
+++ b/app/db/sqlalchemy.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import (
     async_scoped_session,
     create_async_engine,
 )
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.pool.impl import AsyncAdaptedQueuePool
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from app.api.routers import router
 from app.bot.bot import get_bot
 from app.caching.redis_repo import RedisRepo
 from app.constants import BOT_PROJECT_NAME
-from app.db.sqlalchemy import build_db_session_factory
+from app.db.sqlalchemy import build_db_session_factory, close_db_connections
 from app.services.static_files import StaticFilesCustomHeaders
 from app.settings import settings
 
@@ -34,6 +34,9 @@ async def shutdown(bot: Bot) -> None:
 
     # -- Redis --
     await bot.state.redis.close()
+
+    # -- Database --
+    await close_db_connections()
 
 
 def get_application(

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,8 @@ per-file-ignores =
     tests/*:D100,WPS110,WPS116,WPS118,WPS201,WPS204,WPS235,WPS430,WPS442,WPS432
 # too many imported names
     app/bot/commands/common.py:WPS235
+# names shadowing
+    app/db/sqlalchemy.py:WPS442
 
 no-accept-encodings = True
 inline-quotes = double


### PR DESCRIPTION
Изменены настройки подключения к Postgres:

- для настройки пула подключений используется `AsyncAdaptedQueuePool` вместо синхронного `QueuePool`;
- все запросы к базе при обработке команды ботом делаются внутри одной транзакции (`scopefunc=current_task`);
- при остановке бота закрываются все подключения к базе.

## Checklist

- [ ] I've generated a new bot from the async-box template and checked that everything works:
  - [ ] Linters and tests have passed
  - [ ] Bot answers on `test:echo` command
- [ ] I've written good commit message for all commits
- [ ] I've split changes into separate commits where it's appropriate
- [ ] I'll make a release when PR is approved
