### PR TITLE
feat: add database constraint naming convention

### DIFF
--- a/app/db/sqlalchemy.py
+++ b/app/db/sqlalchemy.py
@@ -3,6 +3,7 @@
 from asyncio import current_task
 from typing import Callable
 
+from sqlalchemy import MetaData
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -27,7 +28,15 @@ def make_url_sync(url: str) -> str:
     return "postgresql" + url[url.find(":") :]  # noqa: WPS336
 
 
-Base = declarative_base()
+convention = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+Base = declarative_base(metadata=MetaData(naming_convention=convention))
 
 engine: AsyncEngine = create_async_engine(
     make_url_async(settings.POSTGRES_DSN), poolclass=AsyncAdaptedQueuePool

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,8 @@ per-file-ignores =
 # too many imported names
     app/bot/commands/common.py:WPS235
 # names shadowing
-    app/db/sqlalchemy.py:WPS442
+# `%` string formatting
+    app/db/sqlalchemy.py:WPS442,WPS323
 
 no-accept-encodings = True
 inline-quotes = double


### PR DESCRIPTION
Добавлены naming convention для SQLAlchemy, чтобы названия constraint'ов для базы генерировались автоматически.

# Checklist

- [x] I've generated a new bot from the async-box template and checked that everything works:
  - [x] Linters and tests have passed
  - [x] Bot answers on `test:echo` command
- [x] I've written good commit message for all commits
- [x] I've split changes into separate commits where it's appropriate
- [x] I'll make a release when PR is approved
